### PR TITLE
Fix 0.4.3 build and install python package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mcs07
+* @anthchirp @mcs07

--- a/README.md
+++ b/README.md
@@ -228,5 +228,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@anthchirp](https://github.com/anthchirp/)
 * [@mcs07](https://github.com/mcs07/)
 

--- a/recipe/PR57.patch
+++ b/recipe/PR57.patch
@@ -1,0 +1,22 @@
+From 9c20b879fbeec52a108100e6386457365f2b6f4c Mon Sep 17 00:00:00 2001
+From: Markus Gerstel <markus.gerstel@diamond.ac.uk>
+Date: Wed, 18 Nov 2020 13:39:56 +0000
+Subject: [PATCH] pybind11 is not a runtime dependency
+
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 8541e27f..fe0fe504 100644
+--- a/setup.py
++++ b/setup.py
+@@ -163,7 +163,7 @@ def build_extensions(self):
+     ext_modules=ext_modules,
+     packages=['gemmi-examples'],
+     package_dir={'gemmi-examples': 'examples'},
+-    install_requires=['pybind11>=' + MIN_PYBIND_VER],
++    install_requires=[],
+     setup_requires=['pybind11>=' + MIN_PYBIND_VER],
+     cmdclass={'build_ext': BuildExt},
+     zip_safe=False,

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 cmake \
     -D CMAKE_BUILD_TYPE=Release \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,9 @@ requirements:
     - cmake
     - ninja  # [win]
   host:
-    - setuptools
-    - python
     - pybind11
+    - python
+    - setuptools
     - zlib
   run:
     - python
@@ -49,4 +49,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - anthchirp
     - mcs07

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
   sha256: 9d7aea326f7cbd32a6e609c55bb2249946e87dc2f9dccded2dfe132955dd3dc7
 
 build:
-  number: 0
-  skip: true  # [win and py27]
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
 test:
   commands:
     - gemmi --help
+    - python -m gemmi-examples
     - pip check
   imports:
     - gemmi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://github.com/project-gemmi/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: 9d7aea326f7cbd32a6e609c55bb2249946e87dc2f9dccded2dfe132955dd3dc7
+  patches:
+    - PR57.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
     - python
     - pybind11
     - zlib
+  run:
+    - python
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,11 +20,10 @@ requirements:
     - cmake
     - ninja  # [win]
   host:
+    - setuptools
     - python
     - pybind11
     - zlib
-  run:
-    - python
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,8 +29,11 @@ requirements:
 test:
   commands:
     - gemmi --help
+    - pip check
   imports:
     - gemmi
+  requires:
+    - pip
 
 about:
   home: https://project-gemmi.github.io/


### PR DESCRIPTION
This
* adds `set -e` in the bash builder to catch any catchable errors there
* adds setuptools as build time dependency to fix the build and install the python package (fixes #20)
* adds a test to ensure the python package is installed
* adds a `pip check` test to ensure the resulting python environment is consistent
* backports https://github.com/project-gemmi/gemmi/pull/57 to fix the inconsistent environment
* add myself as maintainer

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
