### PR TITLE
Fix python on osx-arm64

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,7 @@ cmake ${CMAKE_ARGS} \
     -D CMAKE_BUILD_TYPE=Release \
     -D CMAKE_INSTALL_PREFIX=$PREFIX \
     -D CMAKE_PREFIX_PATH=$PREFIX \
+    -D Python_EXECUTABLE=$PYTHON \
     -D USE_PYTHON=ON \
     .
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5f033dded4bf1f3d8fa88636d798aea70bfb2a2f0e209fd517b36d773f83588d
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
When cross-compiling for osx-arm64 on intel osx, the wrong python is found unless we specify with the cmake option. This was missed because running the tests is not possible when cross-compiling.

Fixes https://github.com/conda-forge/gemmi-feedstock/issues/53

See also https://github.com/project-gemmi/gemmi/issues/259

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
