### PR TITLE
Enable linux-ppc64le builds

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -9,4 +9,5 @@ github:
 provider:
   win: azure
   linux_aarch64: azure
+  linux_ppc64le: azure
 test: native_and_emulated


### PR DESCRIPTION
This pull request updates the `conda-forge.yml` configuration file to include support for the `linux_ppc64le` architecture on Azure.

* [`conda-forge.yml`](diffhunk://#diff-478786365dd93f740eb520c2faa03d7a0623273663b75472272c8ef94297bbe2R12): Added `linux_ppc64le` under the `provider` section to enable Azure as the build provider for this architecture.

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
